### PR TITLE
Fix for issue #2

### DIFF
--- a/appendix_a.htm
+++ b/appendix_a.htm
@@ -1174,7 +1174,7 @@ where CF is a Correction Factor, as follows: the CF for each nibble (BCD) digit 
           <th class="left">Least Significant Nibble</th>
         </tr>
         <tr>
-          <td class="right">CF(LSN) = 6 IFF 1)</td><td>C = 1</td>
+          <td class="right">CF(LSN) = 6 IFF 1)</td><td>H = 1</td>
         </tr>
         <tr>
           <td class="right">or 2)</td><td>LSN &gt; 9</td>


### PR DESCRIPTION
This provides the single character fix, changing 'C' to 'H' in the DAA operation description. This fixes  the issue described in issue #2.