### PR TITLE
Errata BGT: incorrect operation conditions - M6809-Docs/m6809pm#4

### DIFF
--- a/appendix_a.htm
+++ b/appendix_a.htm
@@ -534,7 +534,7 @@ When used after a subtract or compare operation, this instruction will branch if
   </tr>
   <tr>
     <td class="bold">Operation:</td><td colspan="2" class="flat">TEMP &larr; MI<br>
-IFF [N &oplus; V] = 0 then PC' &larr; PC + TEMP</td>
+IFF [ N &oplus; V ] = 0 then PC' &larr; PC + TEMP</td>
   </tr>
   <tr>
     <td class="bold">Condition Codes:</td><td colspan="2" class="flat">Not affected.</td>
@@ -557,7 +557,7 @@ When used after a subtract or compare operation on twos complement values, this 
   </tr>
   <tr>
     <td class="bold">Operation:</td><td colspan="2" class="flat">TEMP &larr; MI<br>
-IFF Z &and; [N &oplus; V] = 0 then PC' &larr; PC + TEMP</td>
+IFF <span class="errata">[</span> Z <span class="errata">&or;</span> [ N &oplus; V ] <span class="errata">]</span> = 0 then PC' &larr; PC + TEMP</td>
   </tr>
   <tr>
     <td class="bold">Condition Codes:</td><td colspan="2" class="flat">Not affected.</td>
@@ -670,7 +670,7 @@ The contents of accumulator A or B and memory location M are not affected.</td>
   </tr>
   <tr>
     <td class="bold">Operation:</td><td colspan="2" class="flat">TEMP &larr; MI<br>
-IFF Z &or; [ N &oplus; V ] = 1 then PC' &larr; PC + TEMP</td>
+IFF <span class="errata">[</span> Z &or; [ N &oplus; V ] <span class="errata">]</span> = 1 then PC' &larr; PC + TEMP</td>
   </tr>
   <tr>
     <td class="bold">Condition Codes:</td><td colspan="2" class="flat">Not affected.</td>
@@ -719,7 +719,7 @@ Generally not useful after INC/DEC, LD/ST, and TST/CLR/COM instructions.</td>
   </tr>
   <tr>
     <td class="bold">Operation:</td><td colspan="2" class="flat">TEMP &larr; MI<br>
-IFF (C &or; Z) = 1 then PC' &larr; PC + TEMP</td>
+IFF <span class="correction">[</span> C &or; Z <span class="correction">]</span> = 1 then PC' &larr; PC + TEMP</td>
   </tr>
   <tr>
     <td class="bold">Condition Codes:</td><td colspan="2" class="flat">Not affected.</td>

--- a/index.htm
+++ b/index.htm
@@ -55,6 +55,8 @@ HTMLization errors will just be fixed and listed in the change log at the end of
     <li><a href="sections.htm#tab4-4">PSHU</a> (PDF page 46) - duplicate X, instead of correct S</li>
   </ul></li>
   <li>Appendix A:<ul>
+    <li><a href="appendix_a.htm#BGT">BGT</a> (PDF page 63) - formula from description was incompletely negated into easier readable version for operation paragraph (Thanks to <a href="https://github.com/cmarrin" target="_top">Chris Marrin</a>)</li>
+    <li><a href="appendix_a.htm#BLE">BLE</a> (PDF page 67) - missing outer parenthesis</li>
     <li><a href="appendix_a.htm#DAA">DAA</a> (PDF page 84) - LSN correction checks for H bit (half carry) instead of C bit (Thanks to <a href="https://github.com/cmarrin" target="_top">Chris Marrin</a>)</li>
     <li><a href="appendix_a.htm#PSHU">PSHU</a>, <a href="appendix_a.htm#PULU">PULU</a> (PDF pages 102 &amp; 104) - b6 is S instead of U</li>
   </ul></li>
@@ -67,6 +69,9 @@ HTMLization errors will just be fixed and listed in the change log at the end of
 <h2><a name="errata">Corrections</a></h2>
 <ul>
   <li>Added radix (base) to numbers to show if they are binary &quot;<sub>2</sub>&quot; or hexadecimal &quot;<sub>16</sub>&quot; (may not be 100% yet)</li>
+  <li>Appendix A:<ul>
+    <li><a href="appendix_a.htm#BLS">BLS</a> (PDF page 69) - use square parenthesis as in the other operation conditions</li>
+  </ul></li>
   <li>Appendix D:<ul>
     <li><a href="appendix_d.htm#noteD-1a">Branch Notes</a> (PDF pages 204 &amp; 206) - moved &quot;5(6)&quot; note up to Branch Instructions (Thanks to <a href="https://alex.kazik.de/" target="_top">Alex</a>)</li>
   </ul></li>
@@ -717,6 +722,7 @@ Motorola, Inc. is an Equal Opportunity/Affirmative Action Employer.</p>
 Updated pages with M6809 Docs team information.<br>
 Separated between errata and corrections.<br>
 Added PDF page numbers for easier review and/or reference.</li>
+Added errata for Appendix A: instruction BGT, BLE</li>
   <li>2024-05-04:<br>
 Added errata for Appendix A: instruction DAA</li>
   <li>2023-08-15:<br>


### PR DESCRIPTION
Errata from issue M6809-Docs/m6809pm#4
Motorola tried to negate the formula from the description for an easier version, but then forgot to negate AND to OR, plus to forgot outer parenthesis.